### PR TITLE
chore: upgrade to net6

### DIFF
--- a/samples/Example.Cap.Api/Example.Cap.Api.csproj
+++ b/samples/Example.Cap.Api/Example.Cap.Api.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNetCore.CAP" Version="5.1.2" />
-        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="5.1.2" />
-        <PackageReference Include="DotNetCore.CAP.SqlServer" Version="5.1.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
+        <PackageReference Include="DotNetCore.CAP" Version="6.0.1" />
+        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="6.0.1" />
+        <PackageReference Include="DotNetCore.CAP.SqlServer" Version="6.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/samples/Example.Cap.Api/README.md
+++ b/samples/Example.Cap.Api/README.md
@@ -13,3 +13,12 @@ Run migrations
 ```shell
 dotnet ef database update --project samples/Example.Cap.Api/ --context ExampleDbContext
 ```
+
+Call the API
+
+```
+curl --location --request POST 'https://localhost:5001/order' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "Number": "123"
+}'```

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>1.0.0</VersionPrefix>
-        <VersionSuffix>beta</VersionSuffix>
         <Authors>Rafael Miranda</Authors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Ziggurat.CapAdapter/Ziggurat.CapAdapter.csproj
+++ b/src/Ziggurat.CapAdapter/Ziggurat.CapAdapter.csproj
@@ -1,15 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
         <PackageReference Include="DotNetCore.CAP" Version="5.1.2" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="DotNetCore.CAP" Version="6.0.1" />
+    </ItemGroup>
+
     <ItemGroup>
-      <ProjectReference Include="..\Ziggurat\Ziggurat.csproj" />
+        <ProjectReference Include="..\Ziggurat\Ziggurat.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Ziggurat/Ziggurat.csproj
+++ b/src/Ziggurat/Ziggurat.csproj
@@ -1,14 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
     </ItemGroup>
 
 </Project>

--- a/tests/Ziggurat.Tests/Ziggurat.Tests.csproj
+++ b/tests/Ziggurat.Tests/Ziggurat.Tests.csproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
         <PackageReference Include="ILogger.Moq" Version="1.1.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.10" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
@@ -20,6 +19,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.10" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Related issue: https://github.com/rafaelpadovezi/Ziggurat/issues/10

Enables using ZIggurat on `net6.0` with newer versions of CAP and Entity Framework