### PR TITLE
chore: upgrade cap 7.1.0 and other packages

### DIFF
--- a/samples/Sample.Cap.Mongo/Sample.Cap.Mongo.csproj
+++ b/samples/Sample.Cap.Mongo/Sample.Cap.Mongo.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+      <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
         <PackageReference Include="DotNetCore.CAP.MongoDB" Version="7.1.0" />
         <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="7.1.0" />
     </ItemGroup>

--- a/samples/Sample.Cap.Mongo/Sample.Cap.Mongo.csproj
+++ b/samples/Sample.Cap.Mongo/Sample.Cap.Mongo.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
       <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
-        <PackageReference Include="DotNetCore.CAP.MongoDB" Version="7.0.2" />
-        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="7.0.2" />
+        <PackageReference Include="DotNetCore.CAP.MongoDB" Version="7.1.0" />
+        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="7.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Sample.Cap.SqlServer/Sample.Cap.SqlServer.csproj
+++ b/samples/Sample.Cap.SqlServer/Sample.Cap.SqlServer.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="DotNetCore.CAP" Version="7.1.0" />
         <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="7.1.0" />
         <PackageReference Include="DotNetCore.CAP.SqlServer" Version="7.1.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/samples/Sample.Cap.SqlServer/Sample.Cap.SqlServer.csproj
+++ b/samples/Sample.Cap.SqlServer/Sample.Cap.SqlServer.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNetCore.CAP" Version="7.0.2" />
-        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="7.0.2" />
-        <PackageReference Include="DotNetCore.CAP.SqlServer" Version="7.0.2" />
+        <PackageReference Include="DotNetCore.CAP" Version="7.1.0" />
+        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="7.1.0" />
+        <PackageReference Include="DotNetCore.CAP.SqlServer" Version="7.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/samples/Sample.Cap.SqlServer/Startup.cs
+++ b/samples/Sample.Cap.SqlServer/Startup.cs
@@ -39,6 +39,8 @@ public class Startup
                     o.HostName = Configuration.GetValue<string>("RabbitMQ:HostName");
                     o.Port = Configuration.GetValue<int>("RabbitMQ:Port");
                     o.ExchangeName = Configuration.GetValue<string>("RabbitMQ:ExchangeName");
+                    //set optionally the prefetch count for messages (how many will enqueue in memory at a time before ack)
+                    o.BasicQosOptions = new DotNetCore.CAP.RabbitMQOptions.BasicQos(1);
                 });
             })
             .AddSubscribeFilter<BootstrapFilter>(); // Enrich the message with the required information

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>7.0.0</VersionPrefix>
+        <VersionPrefix>7.0.1</VersionPrefix>
         <Authors>Rafael Miranda</Authors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Ziggurat.CapAdapter/Ziggurat.CapAdapter.csproj
+++ b/src/Ziggurat.CapAdapter/Ziggurat.CapAdapter.csproj
@@ -1,17 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
-        <NoWarn>1591</NoWarn>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
+		<NoWarn>1591</NoWarn>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="DotNetCore.CAP" Version="7.1.0" />
-    </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="DotNetCore.CAP" Version="7.1.0" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Ziggurat\Ziggurat.csproj" />
-    </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="DotNetCore.CAP" Version="7.1.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Ziggurat\Ziggurat.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Ziggurat.CapAdapter/Ziggurat.CapAdapter.csproj
+++ b/src/Ziggurat.CapAdapter/Ziggurat.CapAdapter.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNetCore.CAP" Version="7.0.2" />
+        <PackageReference Include="DotNetCore.CAP" Version="7.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ziggurat.MongoDB/Ziggurat.MongoDB.csproj
+++ b/src/Ziggurat.MongoDB/Ziggurat.MongoDB.csproj
@@ -1,23 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
-        <NoWarn>1591</NoWarn>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
+		<NoWarn>1591</NoWarn>
+	</PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Ziggurat\Ziggurat.csproj" />
-    </ItemGroup>
-    
-    <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
-    </ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\Ziggurat\Ziggurat.csproj" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>Ziggurat.MongoDB.Tests</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Ziggurat.MongoDB.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
 </Project>

--- a/src/Ziggurat.MongoDB/Ziggurat.MongoDB.csproj
+++ b/src/Ziggurat.MongoDB/Ziggurat.MongoDB.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+        <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ziggurat.SqlServer/Ziggurat.SqlServer.csproj
+++ b/src/Ziggurat.SqlServer/Ziggurat.SqlServer.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ziggurat.SqlServer/Ziggurat.SqlServer.csproj
+++ b/src/Ziggurat.SqlServer/Ziggurat.SqlServer.csproj
@@ -1,26 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <NoWarn>1591</NoWarn>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<NoWarn>1591</NoWarn>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
-    </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>Ziggurat.SqlServer.Tests</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Ziggurat.SqlServer.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Ziggurat\Ziggurat.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\Ziggurat\Ziggurat.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Ziggurat/Ziggurat.csproj
+++ b/src/Ziggurat/Ziggurat.csproj
@@ -1,26 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
-        <NoWarn>1591</NoWarn>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
+		<NoWarn>1591</NoWarn>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>Ziggurat.SqlServer</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+	</ItemGroup>	
 
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>Ziggurat.MongoDB</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Ziggurat.SqlServer</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Ziggurat.MongoDB</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
 </Project>

--- a/tests/Ziggurat.MongoDB.Tests/Ziggurat.MongoDB.Tests.csproj
+++ b/tests/Ziggurat.MongoDB.Tests/Ziggurat.MongoDB.Tests.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Ziggurat.SqlServer.Tests/Ziggurat.SqlServer.Tests.csproj
+++ b/tests/Ziggurat.SqlServer.Tests/Ziggurat.SqlServer.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
@@ -24,7 +24,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Ziggurat.Tests/Ziggurat.Tests.csproj
+++ b/tests/Ziggurat.Tests/Ziggurat.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="ILogger.Moq" Version="1.1.10" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
This PR serves multi porposes:
- Add support for target .NET6 as is the LTS  and to CAP to latest 7.10 (.net 6) but with BasicoQOS option
- Upgrade for target .NET7 to CAP to latest 7.10 (.net 6) but with BasicoQOS option
- Aditionally upgrade other packages that are both  .NET6 and 7 compatible