### PR TITLE
chore: update solution dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "08:00"
+      day: "sunday"
+    target-branch: "main"
+    reviewers:
+      - "rafaelpadovezi"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          docker-compose up -d mongoclustersetup sqlserver
+          docker compose up -d mongoclustersetup sqlserver
           ./scripts/start-sonarcloud.sh ${{ secrets.SONAR_TOKEN }} ${{ github.sha }}

--- a/.github/workflows/evaluate-pr.yml
+++ b/.github/workflows/evaluate-pr.yml
@@ -30,11 +30,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker-compose up -d mongoclustersetup sqlserver
+          docker compose up -d mongoclustersetup sqlserver
           ./scripts/start-sonarcloud.sh ${{ secrets.SONAR_TOKEN }} ${{ github.sha }}
       - name: Build the project and run all tests
         if: github.event.pull_request.head.repo.full_name != github.repository
         run: |
-          docker-compose up -d mongoclustersetup sqlserver
+          docker compose up -d mongoclustersetup sqlserver
           dotnet build
           ./scripts/start-tests.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   sqlserver:
     container_name: sql_server

--- a/samples/Sample.Cap.Mongo/Sample.Cap.Mongo.csproj
+++ b/samples/Sample.Cap.Mongo/Sample.Cap.Mongo.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
-        <PackageReference Include="DotNetCore.CAP.MongoDB" Version="8.1.2" />
-        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="8.1.2" />
+        <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
+        <PackageReference Include="DotNetCore.CAP.MongoDB" Version="8.2.0" />
+        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="8.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Sample.Cap.SqlServer/Sample.Cap.SqlServer.csproj
+++ b/samples/Sample.Cap.SqlServer/Sample.Cap.SqlServer.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="8.1.2" />
-        <PackageReference Include="DotNetCore.CAP.SqlServer" Version="8.1.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5">
+        <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="8.2.0" />
+        <PackageReference Include="DotNetCore.CAP.SqlServer" Version="8.2.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,11 +3,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
-    <PackageVersion Include="DotNetCore.CAP" Version="8.1.2" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.27.0" />
+    <PackageVersion Include="DotNetCore.CAP" Version="8.2.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -8,13 +8,13 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.11" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="xunit" Version="2.8.1" />
-    <PackageVersion Include="xunit.extensibility.core" Version="2.8.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.extensibility.core" Version="2.9.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Update dependencies to latest possible¹
- Add dependabot
- Update GA to use `docker compose` command


¹ Using MongoDB.Driver 227.0. When updating MongoDb.Driver to 2.28.0 I got incompatibility errors because CAP MongoDb uses 2.19. The reason is explained [here](https://www.mongodb.com/community/forums/t/net-c-driver-strong-naming/291649/3)