### PR TITLE
feat: add use storage method for cleaner

### DIFF
--- a/samples/Sample.Cap.Mongo/Program.cs
+++ b/samples/Sample.Cap.Mongo/Program.cs
@@ -4,6 +4,7 @@ using Sample.Cap.Mongo;
 using System.Globalization;
 using Ziggurat;
 using Ziggurat.CapAdapter;
+using Ziggurat.MongoDB;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,7 +22,11 @@ builder.Services
     })
     .AddSubscribeFilter<BootstrapFilter>(); // Enrich the message with the required information;
 
-builder.Services.AddZigguratCleaner();
+builder.Services.AddZigguratCleaner(options =>
+{
+    options.CleaningInterval = new TimeSpan(0, 5, 0);
+    options.UseMongoDbStorage();
+});
 
 var app = builder.Build();
 

--- a/samples/Sample.Cap.Mongo/Sample.Cap.Mongo.csproj
+++ b/samples/Sample.Cap.Mongo/Sample.Cap.Mongo.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/Sample.Cap.SqlServer/Sample.Cap.SqlServer.csproj
+++ b/samples/Sample.Cap.SqlServer/Sample.Cap.SqlServer.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/Sample.Cap.SqlServer/Startup.cs
+++ b/samples/Sample.Cap.SqlServer/Startup.cs
@@ -14,6 +14,7 @@ using System;
 using Ziggurat;
 using Ziggurat.CapAdapter;
 using Ziggurat.Logging;
+using Ziggurat.SqlServer;
 
 namespace Sample.Cap.SqlServer;
 
@@ -49,8 +50,9 @@ public class Startup
 
         services.AddZigguratCleaner(options =>
         {
-            options.CleaningInterval = new TimeSpan(1, 0, 0);
+            options.CleaningInterval = new TimeSpan(0, 5, 0);
             options.ExpireAfterInDays = 1;
+            options.UseEntityFrameworkStorage<ExampleDbContext>();
         });
         services
             .AddScoped<OrderCreatedConsumer>()

--- a/src/Ziggurat.MongoDB/CleanerOptionsExtensions.cs
+++ b/src/Ziggurat.MongoDB/CleanerOptionsExtensions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Ziggurat.Idempotency;
+
+namespace Ziggurat.MongoDB;
+
+public static class CleanerOptionsExtensions
+{
+    public static CleanerOptions UseMongoDbStorage(this CleanerOptions options)
+    {
+        options.RegisterStorage = services =>
+        {
+            services.TryAddScoped<IStorage, MongoDbStorage>();
+        };
+        return options;
+    }
+}

--- a/src/Ziggurat.MongoDB/MiddlewareOptionsExtensions.cs
+++ b/src/Ziggurat.MongoDB/MiddlewareOptionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Ziggurat.Idempotency;
 using Ziggurat.MongoDB;
 
@@ -20,13 +21,14 @@ public static class MiddlewareOptionsExtensions
     {
         ZigguratMongoDbOptions.MongoDatabaseName = mongoDatabaseName;
 
+        options.Extensions.Add(IdempotencySetupAction);
+
         static void IdempotencySetupAction(IServiceCollection services)
         {
             services
-                .AddScoped<IStorage, MongoDbStorage>()
+                .TryAddScoped<IStorage, MongoDbStorage>();
+            services
                 .AddScoped<IConsumerMiddleware<TMessage>, IdempotencyMiddleware<TMessage>>();
         }
-
-        options.Extensions.Add(IdempotencySetupAction);
     }
 }

--- a/src/Ziggurat.SqlServer/CleanerOptionsExtensions.cs
+++ b/src/Ziggurat.SqlServer/CleanerOptionsExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Ziggurat.Idempotency;
+
+namespace Ziggurat.SqlServer;
+
+public static class CleanerOptionsExtensions
+{
+    public static CleanerOptions UseEntityFrameworkStorage<TContext>(this CleanerOptions options) where TContext : DbContext
+    {
+        options.RegisterStorage = services =>
+        {
+            services.TryAddScoped<IStorage, EntityFrameworkStorage<TContext>>();
+        };
+        return options;
+    }
+}

--- a/src/Ziggurat.SqlServer/MiddlewareOptionsExtensions.cs
+++ b/src/Ziggurat.SqlServer/MiddlewareOptionsExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Ziggurat.Idempotency;
 using Ziggurat.SqlServer;
 
@@ -20,15 +21,15 @@ public static class MiddlewareOptionsExtensions
         where TContext : DbContext
         where TMessage : IMessage
     {
+        options.Extensions.Add(IdempotencySetupAction);
+
         static void IdempotencySetupAction(IServiceCollection services)
         {
             services
-                .AddScoped<IStorage, EntityFrameworkStorage<TContext>>()
+                .TryAddScoped<IStorage, EntityFrameworkStorage<TContext>>();
+            services
                 .AddScoped<IConsumerMiddleware<TMessage>, IdempotencyMiddleware<TMessage>>();
         }
-
-        options.Extensions.Add(IdempotencySetupAction);
-
     }
 
 }

--- a/src/Ziggurat/Cleaner.cs
+++ b/src/Ziggurat/Cleaner.cs
@@ -22,6 +22,8 @@ public class CleanerOptions
     /// The batch size of delete command
     /// </summary>
     public int BatchSize { get; set; } = 100_000;
+
+    internal Action<IServiceCollection> RegisterStorage { get; set; }
 }
 
 public static class ZigguratExtensions
@@ -44,7 +46,10 @@ public static class ZigguratExtensions
     /// <returns></returns>
     public static IServiceCollection AddZigguratCleaner(this IServiceCollection services, Action<CleanerOptions> optionsAction)
     {
+        var options = new CleanerOptions();
+        optionsAction(options);
         services.Configure(optionsAction);
+        options.RegisterStorage?.Invoke(services);
         return services.AddHostedService<Cleaner>();
     }
 }

--- a/src/Ziggurat/Ziggurat.csproj
+++ b/src/Ziggurat/Ziggurat.csproj
@@ -12,10 +12,22 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Ziggurat.SqlServer.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>Ziggurat.MongoDB</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Ziggurat.MongoDB.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
 
 </Project>

--- a/tests/Ziggurat.MongoDB.Tests/CleanerOptionsExtensionsTests.cs
+++ b/tests/Ziggurat.MongoDB.Tests/CleanerOptionsExtensionsTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Xunit;
+using Ziggurat.Idempotency;
+
+namespace Ziggurat.MongoDB.Tests;
+
+public class CleanerOptionsExtensionsTests
+{
+    [Fact]
+    public void UseMongoDbStorage_ShouldRegister_MongoDbStorage()
+    {
+        // Arrange
+        var options = new CleanerOptions();
+
+        // Act
+        options.UseMongoDbStorage();
+
+        // Assert
+        var services = new ServiceCollection();
+        options.RegisterStorage(services);
+        var storage = services.FirstOrDefault(x => x.ServiceType == typeof(IStorage));
+        storage.ImplementationType.Should().Be(typeof(MongoDbStorage));
+    }
+}

--- a/tests/Ziggurat.MongoDB.Tests/MiddlewareOptionsExtensionsTests.cs
+++ b/tests/Ziggurat.MongoDB.Tests/MiddlewareOptionsExtensionsTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Xunit;
+using Ziggurat.Idempotency;
+using Ziggurat.MongoDB.Tests.Support;
+
+namespace Ziggurat.MongoDB.Tests;
+
+public class MiddlewareOptionsExtensionsTests
+{
+    [Fact]
+    public void UseMongoDbIdempotency_ShouldRegister_MongoDbStorage()
+    {
+        // Arrange
+        var options = new MiddlewareOptions<TestMessage>();
+        const string mongoDatabaseName = "test";
+
+        // Act
+        options.UseMongoDbIdempotency(mongoDatabaseName);
+
+        // Assert
+        var services = new ServiceCollection();
+        foreach (var extention in options.Extensions)
+        {
+            extention(services);
+        }
+
+        var storage = services
+            .FirstOrDefault(x => x.ServiceType == typeof(IStorage) &&
+                            x.ImplementationType == typeof(MongoDbStorage));
+        storage.Should().NotBeNull();
+        var idempotency = services
+            .FirstOrDefault(x => x.ServiceType == typeof(IConsumerMiddleware<TestMessage>) &&
+                            x.ImplementationType == typeof(IdempotencyMiddleware<TestMessage>));
+        idempotency.Should().NotBeNull();
+    }
+}

--- a/tests/Ziggurat.SqlServer.Tests/CleanerOptionsExtensionsTests.cs
+++ b/tests/Ziggurat.SqlServer.Tests/CleanerOptionsExtensionsTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Xunit;
+using Ziggurat.Idempotency;
+using Ziggurat.SqlServer.Tests.Support;
+
+namespace Ziggurat.SqlServer.Tests;
+
+public class CleanerOptionsExtensionsTests
+{
+    [Fact]
+    public void UseEntityFrameworkStorage_ShouldRegister_EntityFrameworkStorage()
+    {
+        // Arrange
+        var options = new CleanerOptions();
+
+        // Act
+        options.UseEntityFrameworkStorage<TestDbContext>();
+
+        // Assert
+        var services = new ServiceCollection();
+        options.RegisterStorage(services);
+        var storage = services.FirstOrDefault(x => x.ServiceType == typeof(IStorage));
+        storage.ImplementationType.Should().Be(typeof(EntityFrameworkStorage<TestDbContext>));
+    }
+}

--- a/tests/Ziggurat.SqlServer.Tests/MiddlewareOptionsExtensionsTests.cs
+++ b/tests/Ziggurat.SqlServer.Tests/MiddlewareOptionsExtensionsTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Xunit;
+using Ziggurat.Idempotency;
+using Ziggurat.SqlServer.Tests.Support;
+
+namespace Ziggurat.SqlServer.Tests;
+
+public class MiddlewareOptionsExtensionsTests
+{
+    [Fact]
+    public void UseEntityFrameworkIdempotency_ShouldRegister_Storage()
+    {
+        // Arrange
+        var options = new MiddlewareOptions<TestMessage>();
+
+        // Act
+        options.UseEntityFrameworkIdempotency<TestMessage, TestDbContext>();
+
+        // Assert
+        var services = new ServiceCollection();
+        foreach (var extention in options.Extensions)
+        {
+            extention(services);
+        }
+
+        var storage = services
+            .FirstOrDefault(x => x.ServiceType == typeof(IStorage) &&
+                                 x.ImplementationType == typeof(EntityFrameworkStorage<TestDbContext>));
+        storage.Should().NotBeNull();
+        var idempotency = services
+            .FirstOrDefault(x => x.ServiceType == typeof(IConsumerMiddleware<TestMessage>) &&
+                                 x.ImplementationType == typeof(IdempotencyMiddleware<TestMessage>));
+        idempotency.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Right now there is no way to use the Cleaner without setting up a Ziggurat consumer in the app. This allows use it on another process